### PR TITLE
fix(storage/index): separate chunk counter in SIMD bytes compare

### DIFF
--- a/internal/storage/index/simd_amd64.s
+++ b/internal/storage/index/simd_amd64.s
@@ -4,164 +4,171 @@
 
 #include "textflag.h"
 
-// bytesEqualAVX2 compares two byte slices using optimized scalar instructions
+// chunkSize defines the number of bytes processed per iteration. Using a
+// constant avoids magic numbers and simplifies adjustments for wider SIMD
+// instructions. See https://en.wikipedia.org/wiki/Word_(computer_architecture)
+#define chunkSize 8
+
+// chunkShift is log2(chunkSize) and enables efficient division using bit
+// shifting. See https://en.wikipedia.org/wiki/Bit_manipulation
+#define chunkShift 3
+
+// chunkMask equals chunkSize-1 and isolates the remaining bytes after chunk
+// processing. See https://en.wikipedia.org/wiki/Mask_(computing)
+#define chunkMask 7
+
+// bytesEqualAVX2 compares two byte slices for equality using scalar
+// instructions as a fallback when AVX2 is unavailable. a and b must have the
+// same length; nil slices are handled safely when their length is zero.
 // func bytesEqualAVX2(a, b []byte) bool
 TEXT ·bytesEqualAVX2(SB), NOSPLIT, $0-49
-	MOVQ a_base+0(FP), SI    // a.ptr
-	MOVQ a_len+8(FP), CX     // a.len
-	MOVQ b_base+24(FP), DI   // b.ptr
-	MOVQ b_len+32(FP), DX    // b.len
-	
-	// Check lengths are equal
-	CMPQ CX, DX
-	JNE  not_equal
-	
-	// Check if length is zero
-	CMPQ CX, $0
-	JE   equal
-	
-	// Use optimized scalar comparison for 8-byte chunks
-	CMPQ CX, $8
-	JL   scalar_compare
-	
-	// Compare 8-byte chunks
-	MOVQ CX, AX
-	SHRQ $3, AX              // AX = len / 8
-	SHLQ $3, AX              // AX = (len / 8) * 8
-	SUBQ AX, CX              // CX = remaining bytes
-	
-	// Compare 8-byte chunks
-chunk_loop:
-	MOVQ (SI), AX            // Load 8 bytes from a
-	CMPQ AX, (DI)            // Compare with b
-	JNE  not_equal
-	ADDQ $8, SI
-	ADDQ $8, DI
-	SUBQ $8, AX
-	JNZ  chunk_loop
-	
-	// Handle remaining bytes
-	CMPQ CX, $0
-	JE   equal
-	
-scalar_compare:
-	// Compare remaining bytes one by one
-	MOVQ CX, AX
-	REP; CMPSB
-	JNE  not_equal
-	
-equal:
-	MOVB $1, ret+48(FP)
-	RET
-	
-not_equal:
-	MOVB $0, ret+48(FP)
-	RET
+        MOVQ a_base+0(FP), SI    // a.ptr
+        MOVQ a_len+8(FP), CX     // a.len
+        MOVQ b_base+24(FP), DI   // b.ptr
+        MOVQ b_len+32(FP), DX    // b.len
 
-// bytesEqualSSE42 compares two byte slices using optimized scalar instructions
+        // Check lengths are equal
+        CMPQ CX, DX
+        JNE  not_equal
+
+        // Check if length is zero
+        CMPQ CX, $0
+        JE   equal
+
+        // Prepare chunk counter and remainder
+        MOVQ CX, R8              // R8 = len
+        SHRQ $chunkShift, R8     // R8 = len / chunkSize
+        ANDQ $chunkMask, CX      // CX = len % chunkSize
+
+        TESTQ R8, R8             // Any full chunks?
+        JE   scalar_compare
+
+chunk_loop:
+        MOVQ (SI), AX            // Load chunk from a
+        CMPQ AX, (DI)            // Compare with b
+        JNE  not_equal
+        ADDQ $chunkSize, SI      // Advance a
+        ADDQ $chunkSize, DI      // Advance b
+        DECQ R8                  // Next chunk
+        JNZ  chunk_loop
+
+        TESTQ CX, CX             // Any remaining bytes?
+        JE   equal
+
+scalar_compare:
+        MOVQ CX, AX              // Load remainder length
+        REP; CMPSB               // Compare remaining bytes
+        JNE  not_equal
+        JMP  equal
+
+equal:
+        MOVB $1, ret+48(FP)
+        RET
+
+not_equal:
+        MOVB $0, ret+48(FP)
+        RET
+
+// bytesEqualSSE42 compares two byte slices for equality using scalar
+// instructions when SSE4.2 is unavailable. a and b must have the same length;
+// nil slices are handled safely when their length is zero.
 // func bytesEqualSSE42(a, b []byte) bool
 TEXT ·bytesEqualSSE42(SB), NOSPLIT, $0-49
-	MOVQ a_base+0(FP), SI    // a.ptr
-	MOVQ a_len+8(FP), CX     // a.len
-	MOVQ b_base+24(FP), DI   // b.ptr
-	MOVQ b_len+32(FP), DX    // b.len
-	
-	// Check lengths are equal
-	CMPQ CX, DX
-	JNE  not_equal
-	
-	// Check if length is zero
-	CMPQ CX, $0
-	JE   equal
-	
-	// Use optimized scalar comparison for 8-byte chunks
-	CMPQ CX, $8
-	JL   scalar_compare
-	
-	// Compare 8-byte chunks
-	MOVQ CX, AX
-	SHRQ $3, AX              // AX = len / 8
-	SHLQ $3, AX              // AX = (len / 8) * 8
-	SUBQ AX, CX              // CX = remaining bytes
-	
-	// Compare 8-byte chunks
-chunk_loop:
-	MOVQ (SI), AX            // Load 8 bytes from a
-	CMPQ AX, (DI)            // Compare with b
-	JNE  not_equal
-	ADDQ $8, SI
-	ADDQ $8, DI
-	SUBQ $8, AX
-	JNZ  chunk_loop
-	
-	// Handle remaining bytes
-	CMPQ CX, $0
-	JE   equal
-	
-scalar_compare:
-	// Compare remaining bytes one by one
-	MOVQ CX, AX
-	REP; CMPSB
-	JNE  not_equal
-	
-equal:
-	MOVB $1, ret+48(FP)
-	RET
-	
-not_equal:
-	MOVB $0, ret+48(FP)
-	RET
+        MOVQ a_base+0(FP), SI    // a.ptr
+        MOVQ a_len+8(FP), CX     // a.len
+        MOVQ b_base+24(FP), DI   // b.ptr
+        MOVQ b_len+32(FP), DX    // b.len
 
-// bytesEqualSSE2 compares two byte slices using optimized scalar instructions
+        // Check lengths are equal
+        CMPQ CX, DX
+        JNE  not_equal
+
+        // Check if length is zero
+        CMPQ CX, $0
+        JE   equal
+
+        // Prepare chunk counter and remainder
+        MOVQ CX, R8              // R8 = len
+        SHRQ $chunkShift, R8     // R8 = len / chunkSize
+        ANDQ $chunkMask, CX      // CX = len % chunkSize
+
+        TESTQ R8, R8             // Any full chunks?
+        JE   scalar_compare
+
+chunk_loop:
+        MOVQ (SI), AX            // Load chunk from a
+        CMPQ AX, (DI)            // Compare with b
+        JNE  not_equal
+        ADDQ $chunkSize, SI      // Advance a
+        ADDQ $chunkSize, DI      // Advance b
+        DECQ R8                  // Next chunk
+        JNZ  chunk_loop
+
+        TESTQ CX, CX             // Any remaining bytes?
+        JE   equal
+
+scalar_compare:
+        MOVQ CX, AX              // Load remainder length
+        REP; CMPSB               // Compare remaining bytes
+        JNE  not_equal
+        JMP  equal
+
+equal:
+        MOVB $1, ret+48(FP)
+        RET
+
+not_equal:
+        MOVB $0, ret+48(FP)
+        RET
+
+// bytesEqualSSE2 compares two byte slices for equality using scalar
+// instructions when SSE2 is unavailable. a and b must have the same length;
+// nil slices are handled safely when their length is zero.
 // func bytesEqualSSE2(a, b []byte) bool
 TEXT ·bytesEqualSSE2(SB), NOSPLIT, $0-49
-	MOVQ a_base+0(FP), SI    // a.ptr
-	MOVQ a_len+8(FP), CX     // a.len
-	MOVQ b_base+24(FP), DI   // b.ptr
-	MOVQ b_len+32(FP), DX    // b.len
-	
-	// Check lengths are equal
-	CMPQ CX, DX
-	JNE  not_equal
-	
-	// Check if length is zero
-	CMPQ CX, $0
-	JE   equal
-	
-	// Use optimized scalar comparison for 8-byte chunks
-	CMPQ CX, $8
-	JL   scalar_compare
-	
-	// Compare 8-byte chunks
-	MOVQ CX, AX
-	SHRQ $3, AX              // AX = len / 8
-	SHLQ $3, AX              // AX = (len / 8) * 8
-	SUBQ AX, CX              // CX = remaining bytes
-	
-	// Compare 8-byte chunks
+        MOVQ a_base+0(FP), SI    // a.ptr
+        MOVQ a_len+8(FP), CX     // a.len
+        MOVQ b_base+24(FP), DI   // b.ptr
+        MOVQ b_len+32(FP), DX    // b.len
+
+        // Check lengths are equal
+        CMPQ CX, DX
+        JNE  not_equal
+
+        // Check if length is zero
+        CMPQ CX, $0
+        JE   equal
+
+        // Prepare chunk counter and remainder
+        MOVQ CX, R8              // R8 = len
+        SHRQ $chunkShift, R8     // R8 = len / chunkSize
+        ANDQ $chunkMask, CX      // CX = len % chunkSize
+
+        TESTQ R8, R8             // Any full chunks?
+        JE   scalar_compare
+
 chunk_loop:
-	MOVQ (SI), AX            // Load 8 bytes from a
-	CMPQ AX, (DI)            // Compare with b
-	JNE  not_equal
-	ADDQ $8, SI
-	ADDQ $8, DI
-	SUBQ $8, AX
-	JNZ  chunk_loop
-	
-	// Handle remaining bytes
-	CMPQ CX, $0
-	JE   equal
-	
+        MOVQ (SI), AX            // Load chunk from a
+        CMPQ AX, (DI)            // Compare with b
+        JNE  not_equal
+        ADDQ $chunkSize, SI      // Advance a
+        ADDQ $chunkSize, DI      // Advance b
+        DECQ R8                  // Next chunk
+        JNZ  chunk_loop
+
+        TESTQ CX, CX             // Any remaining bytes?
+        JE   equal
+
 scalar_compare:
-	// Compare remaining bytes one by one
-	MOVQ CX, AX
-	REP; CMPSB
-	JNE  not_equal
-	
+        MOVQ CX, AX              // Load remainder length
+        REP; CMPSB               // Compare remaining bytes
+        JNE  not_equal
+        JMP  equal
+
 equal:
-	MOVB $1, ret+48(FP)
-	RET
-	
+        MOVB $1, ret+48(FP)
+        RET
+
 not_equal:
-	MOVB $0, ret+48(FP)
-	RET
+        MOVB $0, ret+48(FP)
+        RET


### PR DESCRIPTION
## Summary
- avoid clobbering loaded data by tracking SIMD chunk count in R8
- document SIMD byte-slice equality helpers and replace magic numbers with named constants

## Testing
- `go vet ./...`
- `go test -cover ./...` *(fails: TestGetStatsLegacy in internal/monitoring/metrics)*

------
https://chatgpt.com/codex/tasks/task_e_68b379daf890832bbe0b4819b1de1e20