### PR TITLE
fix(core): release batch memory on clear

### DIFF
--- a/internal/core/batch.go
+++ b/internal/core/batch.go
@@ -189,10 +189,24 @@ func (b *Batch[K, V]) Size() int {
 	return len(b.operations)
 }
 
-// Clear clears all operations from the batch
+// Clear removes all operations and results from the batch.
+//
+// This method resets the batch to its initial state and ensures that
+// references held by the underlying slices are released so the garbage
+// collector can reclaim memory. Failing to clear these references would
+// cause the batch to retain pointers to previously stored keys and values,
+// potentially preventing large objects from being collected.
 func (b *Batch[K, V]) Clear() {
+	for i := range b.operations {
+		b.operations[i] = BatchOperation[K, V]{}
+	}
 	b.operations = b.operations[:0]
+
+	for i := range b.results {
+		b.results[i] = BatchResult[V]{}
+	}
 	b.results = b.results[:0]
+
 	b.committed = false
 }
 

--- a/internal/core/batch_clear_test.go
+++ b/internal/core/batch_clear_test.go
@@ -1,0 +1,45 @@
+package db
+
+import (
+	"runtime"
+	"testing"
+	"time"
+)
+
+// testValue is a large struct used to detect lingering references after clearing a batch.
+type testValue struct {
+	_ [1 << 20]byte // 1 MiB to ensure noticeable memory usage
+}
+
+const (
+	// gcMaxAttempts is the maximum number of garbage collection attempts to wait for finalization.
+	gcMaxAttempts = 10
+	// gcPause defines the delay between garbage collection attempts.
+	gcPause = 10 * time.Millisecond
+)
+
+// TestBatchClearReleasesMemory verifies that Clear removes all references allowing GC to reclaim memory.
+func TestBatchClearReleasesMemory(t *testing.T) {
+	batch := NewBatch[[]byte, *testValue]()
+	val := &testValue{}
+	finalized := make(chan struct{})
+	runtime.SetFinalizer(val, func(*testValue) { close(finalized) })
+
+	batch.Put([]byte("k"), val)
+	batch.Clear()
+
+	// Remove our own reference and trigger GC repeatedly until finalizer runs.
+	val = nil
+	for i := 0; i < gcMaxAttempts; i++ {
+		runtime.GC()
+		runtime.Gosched()
+		select {
+		case <-finalized:
+			return // Success: finalizer executed
+		default:
+			time.Sleep(gcPause)
+		}
+	}
+
+	t.Fatalf("object was not garbage collected after %d attempts", gcMaxAttempts)
+}


### PR DESCRIPTION
## Summary
- ensure Batch.Clear zeroes out operations and results to avoid memory retention
- add GC-based test verifying Clear releases memory

## Testing
- `go test . -cover`
- `go test ./internal/core -cover`


------
https://chatgpt.com/codex/tasks/task_e_68b3833eb68c832b8788d836edc98934

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None
- Performance
  - Clearing batches now promptly releases memory, reducing retention after resets without changing any APIs.
- Bug Fixes
  - Batch resets now fully clear associated data to prevent lingering references.
- Documentation
  - Clarified behavior of batch clearing and memory release.
- Tests
  - Added automated checks to verify memory is freed after clearing batches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->